### PR TITLE
This PR removes 15 medium-risk vulnerabilities.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,31 +18,31 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>3.1.1.RELEASE</version>
+      <version>4.3.4.RELEASE</version>
     </dependency>
 
     <dependency>
         <groupId>org.apache.sling</groupId>
         <artifactId>org.apache.sling.engine</artifactId>
-        <version>2.0.4-incubator</version>
+        <version>2.6.6</version>
     </dependency>
 
     <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-saml-core</artifactId>
-      <version>1.8.1.Final</version>
+      <version>2.4.0.Final</version>
     </dependency>
 
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-jmx</artifactId>
-      <version>1.3</version>
+      <version>3.1.0-RC1</version>
     </dependency>
 
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.3.176</version>
+      <version>1.4.193</version>
     </dependency>
 
     <dependency>
@@ -54,13 +54,13 @@
     <dependency>
       <groupId>net.bull.javamelody</groupId>
       <artifactId>javamelody-core</artifactId>
-      <version>1.59.0</version>
+      <version>1.62.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.orientechnologies</groupId>
       <artifactId>orientdb-server</artifactId>
-      <version>2.1.9</version>
+      <version>2.2.13</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
![SourceClear logo](https://www.sourceclear.com/images/SourceClear_Logo_Primary_Black.png)
Greetings from [SourceClear](https://www.sourceclear.com)! We scanned your repo and found the following vulnerabilities in your direct dependencies. We created this Pull Request to fix them for you.

To find out more about the vulnerabilities, you can search for them in our [SourceClear Registry](https://www.sourceclear.com/registry/explore).

### The details of the vulnerabilities that we fixed are:
#### Medium-risk vulnerabilities
 - **Man-in-the-Middle (MitM) Due to System Property Configuration** in com.h2database:h2:1.3.176
 - **UI Redress Attacks** in org.apache.sling:org.apache.sling.engine:2.0.4-incubator
 - **Infinite Number of Login Attempts** in net.bull.javamelody:javamelody-core:1.59.0
 - **Cross-Site Scripting (XSS)** in net.bull.javamelody:javamelody-core:1.59.0
 - **Cross-site Scripting (XSS)** in net.bull.javamelody:javamelody-core:1.59.0
 - **XML External Entity (XXE) in StAX XMLInputFactory** in org.springframework:spring-web:3.1.1.RELEASE
 - **Information Disclosure Through Timing Attack** in org.springframework:spring-web:3.1.1.RELEASE
 - **XML External Entity (XXE) When Using the JAXB Marshaller** in org.springframework:spring-web:3.1.1.RELEASE
 - **XML External Entity (XXE) in SourceHttpMessageConverter** in org.springframework:spring-web:3.1.1.RELEASE
 - **Cross-site Scripting (XSS) in JavaScriptUtils.javaScriptEscape()** in org.springframework:spring-web:3.1.1.RELEASE
 - **XML External Entity (XXE) in Jaxb2RootElementHttpMessageConverter** in org.springframework:spring-web:3.1.1.RELEASE
 - **SAML Assertion Insertion** in org.keycloak:keycloak-saml-core:1.8.1.Final
 - **Insecure Random Password Auto-Generation** in com.orientechnologies:orientdb-server:2.1.9
 - **Insecure Random Password Generated Using Insufficient Entropy** in com.orientechnologies:orientdb-server:2.1.9
 - **File System Information Disclosure** in org.neo4j:neo4j-jmx:1.3

srcclr-pr-id-03ef0655127ea41ba36c0918b98696fbdbe4cefed3567aef88bcda6ba7809e6f
