### PR TITLE
The latest version of maven needs the compiler target defined 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,11 @@
   <artifactId>example-java-maven</artifactId>
   <version>1.0-SNAPSHOT</version>
 
+<properties>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.mindrot</groupId>


### PR DESCRIPTION
Without the `maven.compiler.source` and `maven.compiler.target` defined in the pom file , the latest version of maven fails to build the project.

For reference see https://github.com/spring-guides/gs-maven/issues/21