### PR TITLE
SourceClear fixes for vulnerable libraries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.srcclr</groupId>
@@ -59,13 +57,53 @@
     <dependency>
       <groupId>net.bull.javamelody</groupId>
       <artifactId>javamelody-core</artifactId>
-      <version>1.59.0</version>
+      <version>1.60.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.orientechnologies</groupId>
       <artifactId>orientdb-server</artifactId>
-      <version>2.1.9</version>
+      <version>2.1.10</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>net.jpountz.lz4</groupId>
+      <artifactId>lz4</artifactId>
+      <version>1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>jline</groupId>
+      <artifactId>jline</artifactId>
+      <version>1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>0.10.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.16</version>
+    </dependency>
+    <dependency>
+      <groupId>com.orientechnologies</groupId>
+      <artifactId>orientdb-client</artifactId>
+      <version>2.1.10</version>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>4.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jackrabbit</groupId>
+      <artifactId>jackrabbit-api</artifactId>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
SourceClear generated this pull request to update the following vulnerable libraries.

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `com.orientechnologies:orientdb-client` | 2.1.9 | 2.1.10 | No |
| MAVEN | `commons-io:commons-io` | 1.1 | 1.2 | No |
| MAVEN | `net.java.dev.jna:jna` | 4.0.0 | 4.1.0 | No |
| MAVEN | `com.orientechnologies:orientdb-server` | 2.1.9 | 2.1.10 | No |
| MAVEN | `jline:jline` | 0.9.94 | 1.0 | No |
| MAVEN | `org.apache.kafka:kafka-clients` | 0.9.0.1 | 0.10.0.0 | No |
| MAVEN | `log4j:log4j` | 1.2.15 | 1.2.16 | No |
| MAVEN | `org.apache.jackrabbit:jackrabbit-api` | 1.4 | 1.5.0 | No |
| MAVEN | `net.jpountz.lz4:lz4` | 1.2.0 | 1.3 | No |
| MAVEN | `net.bull.javamelody:javamelody-core` | 1.59.0 | 1.60.0 | No |


<!-- srcclr-pr-id-a04f3492feb9df28e87810e0548c6531764ce9547e95fea10c8a1f18a4f8f534 -->
