### PR TITLE
SourceClear fixes for vulnerable libraries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,13 +59,13 @@
     <dependency>
       <groupId>net.bull.javamelody</groupId>
       <artifactId>javamelody-core</artifactId>
-      <version>1.59.0</version>
+      <version>1.60.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.orientechnologies</groupId>
       <artifactId>orientdb-server</artifactId>
-      <version>2.1.9</version>
+      <version>2.1.10</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
SourceClear generated this pull request to update the following vulnerable libraries.

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `com.orientechnologies:orientdb-server` | 2.1.9 | 2.1.10 | Maybe |
| MAVEN | `net.bull.javamelody:javamelody-core` | 1.59.0 | 1.60.0 | Maybe |


<!-- srcclr-pr-id-8a78b19ab9c20709deffd1f5aba0bb362cb1c4db46252d9fabaf821844014a90 -->
