### PR TITLE
SourceClear fixes for vulnerable libraries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>org.apache.struts</groupId>
       <artifactId>struts2-core</artifactId>
-      <version>2.5.12</version>
+      <version>2.5.13</version>
     </dependency>
 
     <dependency>
@@ -29,31 +29,31 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>3.1.1.RELEASE</version>
+      <version>3.2.15.RELEASE</version>
     </dependency>
 
     <dependency>
         <groupId>org.apache.sling</groupId>
         <artifactId>org.apache.sling.engine</artifactId>
-        <version>2.0.4-incubator</version>
+        <version>2.4.6</version>
     </dependency>
 
     <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-saml-core</artifactId>
-      <version>1.8.1.Final</version>
+      <version>2.5.5.Final</version>
     </dependency>
 
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-jmx</artifactId>
-      <version>1.3</version>
+      <version>3.0.0-M05</version>
     </dependency>
 
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.3.176</version>
+      <version>1.4.183</version>
     </dependency>
 
     <dependency>
@@ -65,13 +65,13 @@
     <dependency>
       <groupId>net.bull.javamelody</groupId>
       <artifactId>javamelody-core</artifactId>
-      <version>1.59.0</version>
+      <version>1.62.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.orientechnologies</groupId>
       <artifactId>orientdb-server</artifactId>
-      <version>2.1.9</version>
+      <version>2.1.11</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
SourceClear generated this pull request to update the following vulnerable libraries.

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `org.apache.struts:struts2-core` | 2.5.12 | 2.5.13 | No |
| MAVEN | `net.bull.javamelody:javamelody-core` | 1.59.0 | 1.62.0 | Maybe |
| MAVEN | `com.orientechnologies:orientdb-server` | 2.1.9 | 2.1.11 | Maybe |
| MAVEN | `org.springframework:spring-web` | 3.1.1.RELEASE | 3.2.15.RELEASE | Maybe |
| MAVEN | `org.neo4j:neo4j-jmx` | 1.3 | 3.0.0-M05 | Maybe |
| MAVEN | `com.h2database:h2` | 1.3.176 | 1.4.183 | Maybe |
| MAVEN | `org.keycloak:keycloak-saml-core` | 1.8.1.Final | 2.5.5.Final | Maybe |
| MAVEN | `org.apache.sling:org.apache.sling.engine` | 2.0.4-incubator | 2.4.6 | Maybe |

<!-- srcclr-pr-id-b3c162483f6d2b01b5e53d9b05d49d156a641a440f2557c6e314b5d4fdd40bb1 -->
