### PR TITLE
SourceClear fixes for vulnerable libraries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,5 +73,11 @@
       <artifactId>orientdb-server</artifactId>
       <version>2.1.9</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch</artifactId>
+      <version>2.3.3</version>
+    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>3.1.1.RELEASE</version>
+      <version>3.2.15.RELEASE</version>
     </dependency>
 
     <dependency>
@@ -47,13 +47,13 @@
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-jmx</artifactId>
-      <version>1.3</version>
+      <version>3.0.0-M05</version>
     </dependency>
 
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.3.176</version>
+      <version>1.4.183</version>
     </dependency>
 
     <dependency>
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>com.orientechnologies</groupId>
       <artifactId>orientdb-server</artifactId>
-      <version>2.1.9</version>
+      <version>2.1.10</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/srcclr/Main.java
+++ b/src/main/java/com/srcclr/Main.java
@@ -3,18 +3,22 @@ package com.srcclr;
 import org.apache.commons.fileupload.MultipartStream;
 import org.apache.xml.security.signature.XMLSignatureInput;
 import org.mindrot.jbcrypt.BCrypt;
+import org.springframework.web.util.UriUtils;
 
 import java.io.ByteArrayInputStream;
 
 public class Main {
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws Exception {
     String candidate = args[0];
     String hashed = BCrypt.hashpw(candidate, BCrypt.gensalt(12));
 
     BCrypt.checkpw(candidate, hashed);
 
     filterXMLSignature();
+
+    // Update Advisor: changed in the upgrade from Spring Web 3.1.1.RELEASE to 3.2.15.RELEASE
+    UriUtils.encodeFragment("", "");
   }
 
   private static void filterXMLSignature() {


### PR DESCRIPTION
SourceClear generated this pull request to update the following vulnerable libraries.

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `org.springframework:spring-web` | 3.1.1.RELEASE | 3.2.15.RELEASE | Maybe |
| MAVEN | `org.neo4j:neo4j-jmx` | 1.3 | 3.0.0-M05 | No |
| MAVEN | `com.h2database:h2` | 1.3.176 | 1.4.183 | No |
| MAVEN | `com.orientechnologies:orientdb-server` | 2.1.9 | 2.1.10 | No |

<!-- srcclr-pr-id-745b4570f7fe75c2828ca3aa068ad5385c63d64e0e9e66c60ed4f773dbe117f7 -->
