### PR TITLE
SourceClear fixes for vulnerable libraries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,25 +29,25 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>3.1.1.RELEASE</version>
+      <version>4.3.20.RELEASE</version>
     </dependency>
 
     <dependency>
         <groupId>org.apache.sling</groupId>
         <artifactId>org.apache.sling.engine</artifactId>
-        <version>2.0.4-incubator</version>
+        <version>2.4.6</version>
     </dependency>
 
     <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-saml-core</artifactId>
-      <version>1.8.1.Final</version>
+      <version>2.5.5.Final</version>
     </dependency>
 
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-jmx</artifactId>
-      <version>1.3</version>
+      <version>3.0.0-M05</version>
     </dependency>
 
     <dependency>
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>com.orientechnologies</groupId>
       <artifactId>orientdb-server</artifactId>
-      <version>2.1.9</version>
+      <version>2.1.11</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
SourceClear generated this pull request to update the following vulnerable libraries.

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `org.springframework:spring-web` | 3.1.1.RELEASE | 4.3.20.RELEASE | Maybe |
| MAVEN | `org.neo4j:neo4j-jmx` | 1.3 | 3.0.0-M05 | No |
| MAVEN | `com.orientechnologies:orientdb-server` | 2.1.9 | 2.1.11 | No |
| MAVEN | `org.keycloak:keycloak-saml-core` | 1.8.1.Final | 2.5.5.Final | No |
| MAVEN | `org.apache.sling:org.apache.sling.engine` | 2.0.4-incubator | 2.4.6 | No |

<!-- srcclr-pr-id-cca68f26a052a4443db864ee558e52625a030c86f164a0c555a4b8a907600f84 -->
